### PR TITLE
send content when fetching all notes

### DIFF
--- a/controllers/api.js
+++ b/controllers/api.js
@@ -111,7 +111,7 @@ exports.read = function (req, res) {
 
         for (var i = 0; i < note.length; i++) {
             if (note[i].id == id) {
-                list.push({ id: note[i]._id, heading: note[i].heading, date: note[i].date });
+                list.push({ id: note[i]._id, heading: note[i].heading, content: note[i].content , date: note[i].date });
             }
         }
 


### PR DESCRIPTION
They want to display content on site load and not just when you click on a note. I added content to be sent when all notes are fetched.